### PR TITLE
Fix personality traits not affecting stats for historical leaders

### DIFF
--- a/Changelog Alex MP mod.txt
+++ b/Changelog Alex MP mod.txt
@@ -44,6 +44,7 @@
 - Attempt to fix Carrier wing wipe bug by making naval bombers gain efficiency after zone switch really fast.
 - Attempt to fix Carrier wing wipe bug by making naval aircombat less lethal.
 - Attempt to fix Carrier wing wipe bug by making Air AI value efficiency more and naval strike less.
+- Fixed some personality traits not affecting stats for historical leaders
 
 
 Key previous features of the mod:

--- a/events/amm_fixup.txt
+++ b/events/amm_fixup.txt
@@ -1,0 +1,43 @@
+﻿###########################
+# Alex Multi Mod Fixup Events
+###########################
+
+add_namespace = amm_fixup
+
+country_event = {
+	id = amm_fixup.1
+	title = amm_fixup.1.t
+	desc = amm_fixup.1.d
+	picture = GFX_report_event_dead_soldiers
+	fire_only_once = yes
+
+	trigger = {
+		tag = HAI
+	}
+	mean_time_to_happen = {
+		days = 1
+	}
+	
+	option = { 
+		name = amm_fixup.1.a
+		ai_chance = { factor = 100 }
+		every_country = {
+			every_army_leader = {
+				if = {
+					limit = { has_trait = brilliant_strategist }
+					add_attack = 1
+					add_planning = 1
+				}
+				else_if = {
+					limit = { has_trait = inflexible_strategist }
+					add_defense = 1
+					add_logistics = 1
+				}
+				else_if = {
+					limit = { has_trait = harsh_leader }
+					add_attack = 1
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
There is currently a bug which doesn't actually add stats to leaders with personality traits that do add them. brilliant_strategist doesn't get +1 to attack and planning, inflexible_strategist to defense and logistics and harsh leader to attack.

Leaders affected: 3 CHI, 6 UK, 4 FRA, 7 GER, 2 ITA, 3 JAP, 8 SOV, 7 USA.

The pull request just adds an on_action that fixes the issue by manually adding correct stats on game startup.